### PR TITLE
Add to Readme note about functions exported to string:

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Function                       | Info   |
 ------------------------------ |------- |
 htmlEntities                   | Return table with about module and version
 htmlEntities.decode(input)     | Decode html entities to text
+string:htmlDecode(input)       | Same as above
 htmlEntities.encode(input)     | Encode text to html entities (in ASCII) NOTE: Emoji is not supported here
+string:htmlEncode(input)       | Same as above
 htmlEntities.ASCII_HEX(input)  | Decode for ASCII HEX
 htmlEntities.ASCII_DEC(input)  | Decode for ASCII DEC
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Function                       | Info   |
 ------------------------------ |------- |
 htmlEntities                   | Return table with about module and version
 htmlEntities.decode(input)     | Decode html entities to text
-string:htmlDecode(input)       | Same as above
+string:htmlDecode()            | Same as above
 htmlEntities.encode(input)     | Encode text to html entities (in ASCII) NOTE: Emoji is not supported here
-string:htmlEncode(input)       | Same as above
+string:htmlEncode()            | Same as above
 htmlEntities.ASCII_HEX(input)  | Decode for ASCII HEX
 htmlEntities.ASCII_DEC(input)  | Decode for ASCII DEC
 


### PR DESCRIPTION
There's currently no mention that `string:htmlDecode` and `string:htmlEncode` are exported to the string table.

While at it, I find returning `false` on nil input isn't the way how other Lua `string.` functions handle this situation, they'd return nil as well. 
```
string.htmlDecode(nil) --> nil
```

Though, I'm not sure it's a good idea to change current behaviour.