### PR TITLE
Improve regex to not match empty html entities

### DIFF
--- a/src/htmlEntities.lua
+++ b/src/htmlEntities.lua
@@ -2353,8 +2353,8 @@ function htmlEntities.decode (input)
 	end
 	local output = string.gsub(input, '&[%w#]-;', htmlEntities_table)
 	if ASCII_htmlEntities then
-		output = string.gsub(output, '&#x([%w%d]*);', htmlEntities.ASCII_DEC)
-		output = string.gsub(output, '&#([%d]*);', htmlEntities.ASCII_HEX)
+		output = string.gsub(output, '&#x([%w%d]+);', htmlEntities.ASCII_DEC)
+		output = string.gsub(output, '&#([%d]+);', htmlEntities.ASCII_HEX)
 	end
 
 	if debug_htmlEntities then print('>>'..output) end


### PR DESCRIPTION
Thank you for this module! I have used it to decode millions of old forum posts, it works well, but I have discovered an error with malformed html entities, specifically with ```&#;```.

Example:
```
htmlEntities.decode('hello world &#;')
```
Leads to:
```
htmlentities.lua:2317: bad argument #1 to 'abs' (number expected, got string)
```

To solve this bug, I have changed the matching regex from ```*``` to ```+``` to match only entities with at least one occurrence.
